### PR TITLE
use paketobuildpacks containers instead of paketocommunity

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -85,7 +85,7 @@ func CreateConfigTomlFileContent(defaultNodeVersion string, nodejsStacks []Stack
 			"id":      "node",
 			"stacks":  []string{stackId},
 			"version": fmt.Sprintf("%s.1000", stack.NodeVersion),
-			"source":  fmt.Sprintf("paketocommunity/run-nodejs-%s-ubi-base", stack.NodeVersion),
+			"source":  fmt.Sprintf("paketobuildpacks/run-nodejs-%s-ubi8-base", stack.NodeVersion),
 		}
 		dependencies = append(dependencies, dependency)
 	}


### PR DESCRIPTION
After the move this change is needed ot use the containers that are being published in the paketobuildpacks docker namespace instead of paketocommunity

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
