### PR TITLE
Refactor publish script

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -141,7 +141,7 @@ jobs:
         image_name="localhost:5000/npm-install:latest"
 
         ./scripts/publish.sh \
-          --buildpack-archive ./build/buildpack.tgz \
+          --buildpack-type ${{ steps.get_buildpack_type.outputs.buildpack_type }} \
           --image-ref $image_name
 
         echo "digest=$(sudo skopeo inspect "docker://${image_name}" --tls-verify=false | jq -r .Digest)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/push-buildpackage.yml
+++ b/.github/workflows/push-buildpackage.yml
@@ -62,15 +62,17 @@ jobs:
     - name: Parse Configs
       id: parse_configs
       run: |
+        registries_filename="${{ env.REGISTRIES_FILENAME }}"
+
         push_to_dockerhub=true
         push_to_gcr=false
 
-        if [[ -f $REGISTRIES_FILENAME ]]; then
-          if jq 'has("dockerhub")' $REGISTRIES_FILENAME > /dev/null; then
-            push_to_dockerhub=$(jq '.dockerhub' $REGISTRIES_FILENAME)
+        if [[ -f $registries_filename ]]; then
+          if jq 'has("dockerhub")' $registries_filename > /dev/null; then
+            push_to_dockerhub=$(jq '.dockerhub' $registries_filename)
           fi
-          if jq 'has("GCR")' $REGISTRIES_FILENAME > /dev/null; then
-            push_to_gcr=$(jq '.GCR' $REGISTRIES_FILENAME)
+          if jq 'has("GCR")' $registries_filename > /dev/null; then
+            push_to_gcr=$(jq '.GCR' $registries_filename)
           fi
         fi
 
@@ -84,6 +86,15 @@ jobs:
         if [[ "$buidpackTomlVersion" != "$githubReleaseVersion" ]]; then
           echo "Version in buildpack.toml ($buidpackTomlVersion) and github release ($githubReleaseVersion) are not identical"
           exit 1
+        fi
+
+    - name: Get buildpack type
+      id: get_buildpack_type
+      run: |
+        if [ -f "extension.toml" ]; then
+          echo "buildpack_type=extension" >> "$GITHUB_OUTPUT"
+        else
+          echo "buildpack_type=buildpack" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Docker login docker.io
@@ -111,7 +122,8 @@ jobs:
         echo "${DOCKERHUB_PASSWORD}" | sudo skopeo login --username "${DOCKERHUB_USERNAME}" --password-stdin ${DOCKERHUB_REGISTRY}
 
         ./scripts/publish.sh \
-          --buildpack-archive ./buildpack.tgz \
+          --archive-path ./buildpack.tgz \
+          --buildpack-type ${{ steps.get_buildpack_type.outputs.buildpack_type }} \
           --image-ref "${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}"
 
         ## Validate that the digest pushed to registry matches with the one mentioned on the readme file
@@ -143,7 +155,7 @@ jobs:
       with:
         id: ${{ github.repository }}
         version: ${{ steps.event.outputs.tag_full }}
-        address: ${{ steps.push.outputs.image }}@${{ steps.push.outputs.digest }}
+        address: index.docker.io/${{ steps.push.outputs.image }}@${{ steps.push.outputs.digest }}
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
   failure:

--- a/registries.json
+++ b/registries.json
@@ -1,4 +1,0 @@
-{
-  "dockerhub": true,
-  "GCR": false
-}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -13,13 +13,18 @@ source "${ROOT_DIR}/scripts/.util/tools.sh"
 source "${ROOT_DIR}/scripts/.util/print.sh"
 
 function main {
-  local buildpack_archive image_ref token
+  local archive_path buildpack_type image_ref token
   token=""
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
-    --buildpack-archive | -b)
-      buildpack_archive="${2}"
+    --archive-path | -a)
+      archive_path="${2}"
+      shift 2
+      ;;
+
+    --buildpack-type | -bt)
+      buildpack_type="${2}"
       shift 2
       ;;
 
@@ -52,38 +57,44 @@ function main {
 
   if [[ -z "${image_ref:-}" ]]; then
     usage
-    echo
     util::print::error "--image-ref is required"
   fi
 
-  if [[ -z "${buildpack_archive:-}" ]]; then
-    util::print::info "Using default buildpack archive path: ${ROOT_DIR}/build/buildpack.tgz"
-    buildpack_archive="${ROOT_DIR}/build/buildpack.tgz"
+  if [[ -z "${buildpack_type:-}" ]]; then
+    usage
+    util::print::error "--buildpack-type is required"
+  fi
+
+  if [[ ${buildpack_type} != "buildpack" && ${buildpack_type} != "extension" ]]; then
+    usage
+    util::print::error "--buildpack-type accepted values: [\"buildpack\",\"extension\"]"
+  fi
+
+  if [[ -z "${archive_path:-}" ]]; then
+    util::print::info "Using default archive path: ${ROOT_DIR}/build/buildpack.tgz"
+    archive_path="${ROOT_DIR}/build/buildpack.tgz"
+  else
+    archive_path="${archive_path}"
   fi
 
   repo::prepare
 
   tools::install "${token}"
 
-  buildpack_type=buildpack
-  if [ -f "${ROOT_DIR}/extension.toml" ]; then
-    buildpack_type=extension
-  fi
-
-  buildpack::publish "${image_ref}" "${buildpack_type}"
+  buildpack::publish "${image_ref}" "${buildpack_type}" "${archive_path}"
 }
 
 function usage() {
   cat <<-USAGE
-publish.sh --version <version> [OPTIONS]
-
 Publishes a buildpack or an extension in to a registry.
 
 OPTIONS
+  -a, --archive-path <filepath>       Path to the buildpack or extension arhive (default: ${ROOT_DIR}/build/buildpack.tgz) (optional)
   -h, --help                          Prints the command usage
-  -b, --buildpack-archive <filepath>  Path to the buildpack arhive (default: ${ROOT_DIR}/build/buildpack.tgz) (optional)
   -i, --image-ref <ref>               List of image reference to publish to (required)
+  -bt --buildpack-type <string>       Type of buildpack to publish (accepted values: buildpack, extension) (required)
   -t, --token <token>                 Token used to download assets from GitHub (e.g. jam, pack, etc) (optional)
+
 USAGE
 }
 
@@ -106,19 +117,21 @@ function tools::install() {
 
 function buildpack::publish() {
 
-  local image_ref buildpack_type
+  local image_ref buildpack_type archive_path
   image_ref="${1}"
   buildpack_type="${2}"
+  archive_path="${3}"
 
   util::print::title "Publishing ${buildpack_type}..."
 
   util::print::info "Extracting archive..."
   tmp_dir=$(mktemp -d -p $ROOT_DIR)
-  tar -xvf $buildpack_archive -C $tmp_dir
+  tar -xvf $archive_path -C $tmp_dir
 
   util::print::info "Publishing ${buildpack_type} to ${image_ref}"
+
   pack \
-    buildpack package $image_ref \
+    ${buildpack_type} package $image_ref \
     --path $tmp_dir \
     --format image \
     --publish


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR does below things:
* removes registries.json file, as is no longer necessary
* removes the --buildpack-archive flag from the publish.sh script and adds --archive-path flag instead
* introduces a new flag called --buildpack-type which is used to specify how the pack cli will pack the builpack (as an extension or as a buildpack)
* Fixes the push-buildpackage workflow.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
