### PR TITLE
Selecting the correct run image os based on the build image os

### DIFF
--- a/internal/utils/init_test.go
+++ b/internal/utils/init_test.go
@@ -18,5 +18,6 @@ func TestUnitUtils(t *testing.T) {
 	suite("testGenerateBuildDockerfile", testGenerateBuildDockerfile)
 	suite("testGenerateRunDockerfile", testGenerateRunDockerfile)
 	suite("testGetBuildPackages", testGetBuildPackages)
+	suite("testGetOsCodenameFromStackId", testGetOsCodenameFromStackId)
 	suite.Run(t)
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -51,7 +51,12 @@ func GenerateConfigTomlContentFromImagesJson(imagesJsonPath string, stackId stri
 		return []byte{}, err
 	}
 
-	configTomlContent, err := CreateConfigTomlFileContent(defaultNodeVersion, nodejsStacks, stackId)
+	osCodename, err := GetOsCodenameFromStackId(stackId)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	configTomlContent, err := CreateConfigTomlFileContent(defaultNodeVersion, nodejsStacks, stackId, osCodename)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -76,7 +81,7 @@ func GetDefaultNodeVersion(stacks []StackImages) (string, error) {
 	}
 }
 
-func CreateConfigTomlFileContent(defaultNodeVersion string, nodejsStacks []StackImages, stackId string) (bytes.Buffer, error) {
+func CreateConfigTomlFileContent(defaultNodeVersion string, nodejsStacks []StackImages, stackId string, osCodename string) (bytes.Buffer, error) {
 
 	var dependencies []map[string]interface{}
 
@@ -85,7 +90,7 @@ func CreateConfigTomlFileContent(defaultNodeVersion string, nodejsStacks []Stack
 			"id":      "node",
 			"stacks":  []string{stackId},
 			"version": fmt.Sprintf("%s.1000", stack.NodeVersion),
-			"source":  fmt.Sprintf("paketobuildpacks/run-nodejs-%s-ubi8-base", stack.NodeVersion),
+			"source":  fmt.Sprintf("paketobuildpacks/run-nodejs-%s-%s-base", stack.NodeVersion, osCodename),
 		}
 		dependencies = append(dependencies, dependency)
 	}
@@ -251,4 +256,21 @@ func GetBuildPackages(imageId string, nodeVersion int) (string, error) {
 	}
 
 	return "", fmt.Errorf("unsupported image ID: %s", imageId)
+}
+
+// Application ran, i have to figure out to how to catch this scenario next time on ubinotjsextn
+func GetOsCodenameFromStackId(stackId string) (string, error) {
+
+	stackIdPrefix := "io.buildpacks.stacks."
+	osCodename := strings.TrimPrefix(stackId, stackIdPrefix)
+
+	if !strings.HasPrefix(stackId, stackIdPrefix) {
+		return "", fmt.Errorf("failed to extract os codename from stack id '%s'. stack id is missing the required prefix '%s'", stackId, stackIdPrefix)
+	}
+
+	if len(osCodename) == 0 {
+		return "", fmt.Errorf("failed to extract os codename from stack id '%s': os codename length cannot be zero", stackId)
+	}
+
+	return osCodename, nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -249,7 +249,7 @@ func GetBuildPackages(imageId string, nodeVersion int) (string, error) {
 	case "io.buildpacks.stacks.ubi9":
 		switch nodeVersion {
 		case 18, 20, 22:
-			return "make gcc gcc-c++ git openssl-devel nodejs npm nodejs-nodemon nss_wrapper-libs", nil
+			return "make gcc gcc-c++ git openssl-devel nodejs npm nodejs-nodemon nss_wrapper-libs python3", nil
 		default:
 			return "", fmt.Errorf("unsupported Node.js version %d for image %s", nodeVersion, imageId)
 		}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Currently, the selection of the run image os is hardcoded and fixed to ubi8 https://github.com/paketo-buildpacks/ubi-nodejs-extension/blob/3069638ce312cc38d40516e474c7d7464f838875/internal/utils/utils.go#L88 . This does not allow selecting run images with ubi9, ubi10, etc. os. This PR alters the current implementation to enable selecting the operating system of the run image. This is determined by the build image stack id, therefore we extract the ubi8, ubi9, ubi10 etc. from the stack id. We use a regex to extract the ubi8, ubi9, etc. prefix from the stack id and not an if else  statement. This is intentionally as we avoid additional PRs each time we want the extension to support a new run image. We also do a basic check on the length of the ubx prefix if is an empty string, for friendlier errors, as in case of a wrong run image name, it will fail anyway during build.

In addition to the aforementioned implementation, we install the python package as it is necessary for running application that has the python as a dependency on their node_modules.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
